### PR TITLE
Version 1.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.0.0-rc.1</Version>
+    <Version>1.0.0</Version>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
### Features
- SignTool target task to sign assemblies after build using a file certificate.
- Support project with `Exe` and `Library` output type.
### Updated
- Update `SignToolImportance` default to `High`.
- Update `SignToolTarget` to use propriety `SignToolAfterTargets` in the `AfterTargets` with default `CoreBuild`.
- Update `SignToolTarget` to use propriety `SignToolBeforeTargets` in the `BeforeTargets` with default ``.
- Update `SignToolFile` not exist to warning message.
### Sample
- Add `signfile.pfx` file to sign the assembly, copy from [ricaun.Security.WinTrust](https://github.com/ricaun-io/ricaun.Security.WinTrust/)
### Tests
- Sign with local file certificate.